### PR TITLE
修复Android5.0以下使用cordova内核cenarius不起作用的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ out/
 # Gradle files
 .gradle/
 build/
-
+*/build/
 # Local configuration file (sdk path, etc)
 local.properties
 
@@ -38,3 +38,9 @@ captures/
 
 # Keystore files
 *.jks
+.idea/
+cenarius/libs/
+*/src/androidTest/
+cenarius/src/main/res/drawable/
+*/src/test/
+.idea/libraries/

--- a/core/src/main/java/org/apache/cordova/engine/SystemWebViewClient.java
+++ b/core/src/main/java/org/apache/cordova/engine/SystemWebViewClient.java
@@ -348,13 +348,13 @@ public class SystemWebViewClient extends CenariusWebViewClient {
                 return new WebResourceResponse(result.mimeType, "UTF-8", result.inputStream);
             }
             // If we don't need to special-case the request, let the browser load it.
-            return null;
+            return super.shouldInterceptRequest(view, url);
         } catch (IOException e) {
             if (!(e instanceof FileNotFoundException)) {
                 LOG.e(TAG, "Error occurred while loading a file (returning a 404).", e);
             }
             // Results in a 404.
-            return new WebResourceResponse("text/plain", "UTF-8", null);
+            return super.shouldInterceptRequest(view, url);
         }
     }
 


### PR DESCRIPTION
修复Android5.0以下使用cordova内核cenarius不起作用的问题，主要修改了cordova代码部分的webviewclient，调用父类方法处理